### PR TITLE
chore: reduced costs per new model

### DIFF
--- a/src/components/Calculator.vue
+++ b/src/components/Calculator.vue
@@ -45,8 +45,8 @@
 </template>
 
 <script>
-const vcpuHourPrice = 0.0506;
-const memoryGbHourPrice = 0.0127;
+const vcpuHourPrice = 0.04048;
+const memoryGbHourPrice = 0.004445;
 
 const mapSequenceToSelections = array => array.map(x => ({
   value: x,


### PR DESCRIPTION
reduce cpu by 20%
reduce memory by 65%

> Effective January 7th, 2019 Fargate pricing per vCPU per second is being reduced by 20%, and pricing per GB of memory per second is being reduced by 65%.

https://aws.amazon.com/blogs/compute/aws-fargate-price-reduction-up-to-50/