### PR TITLE
Adding regional pricing and cost breakdown

### DIFF
--- a/src/components/Calculator.vue
+++ b/src/components/Calculator.vue
@@ -40,13 +40,24 @@
 
     =
 
-    <h2>${{ totalPrice }}/month</h2>
+    <h2>${{ totalPrice.toFixed(3) }} USD</h2>
+
+    <h4>${{ cpuPrice.toFixed(3) }} on CPU ({{ (cpuPrice / totalPrice * 100).toFixed(0) }}%)</h4>
+    <h4>${{ memoryPrice.toFixed(3) }} on RAM ({{ (memoryPrice / totalPrice * 100).toFixed(0) }}%)</h4>
+
+    <el-select v-model="region" placeholder="Select">
+      <el-option
+              v-for="item in regions"
+              :key="item.value"
+              :label="item.label"
+              :value="item.value">
+      </el-option>
+    </el-select>
   </div>
 </template>
 
 <script>
-const vcpuHourPrice = 0.04048;
-const memoryGbHourPrice = 0.004445;
+import { pricing, regions } from '../pricing';
 
 const mapSequenceToSelections = array => array.map(x => ({
   value: x,
@@ -98,15 +109,31 @@ export default {
       memory: 0.5,
       time: 'hours',
       hours: 1,
+      region: 'us-east-1',
+      regions: regions,
     };
   },
   computed: {
     memoryOptions: function() { // eslint-disable-line
       return getMemoryOptions(this.vcpu);
     },
+    regionPricing: function() { // eslint-disable-line
+      return pricing[this.region];
+    },
+    cpuPerHour: function() { // eslint-disable-line
+      return this.regionPricing.vCpuPerHour;
+    },
+    memoryPerHour: function() { // eslint-disable-line
+      return this.regionPricing.memoryGbPerHour;
+    },
+    cpuPrice: function() { // eslint-disable-line
+      return this.hours * this.vcpu * this.cpuPerHour;
+    },
+    memoryPrice: function() { // eslint-disable-line
+      return this.hours * this.memory * this.memoryPerHour;
+    },
     totalPrice: function() { // eslint-disable-line
-      return ((this.hours * this.vcpu * vcpuHourPrice)
-        + (this.hours * this.memory * memoryGbHourPrice)).toFixed(3);
+      return this.cpuPrice + this.memoryPrice;
     },
   },
   methods: {

--- a/src/components/Calculator.vue
+++ b/src/components/Calculator.vue
@@ -110,7 +110,7 @@ export default {
       time: 'hours',
       hours: 1,
       region: 'us-east-1',
-      regions: regions,
+      regions,
     };
   },
   computed: {

--- a/src/components/Calculator.vue
+++ b/src/components/Calculator.vue
@@ -13,7 +13,7 @@
 
     <div v-if="time === 'hours'" style="display: inline">
       x 
-      <el-input-number v-model="hours" controls-position="right" :min="1" :max="730"></el-input-number>
+      <el-input-number v-model="hours" controls-position="right" :min="0" :max="730"></el-input-number>
     </div>
 
     x

--- a/src/pricing.js
+++ b/src/pricing.js
@@ -1,0 +1,109 @@
+export const regions = [
+  {
+    value: 'us-east-1',
+    label: 'N. Virginia, us-east-1',
+  },
+  {
+    value: 'us-east-2',
+    label: 'Ohio, us-east-2',
+  },
+  {
+    value: 'us-west-1',
+    label: 'N. California, us-west-1',
+  },
+  {
+    value: 'us-west-2',
+    label: 'Oregon, us-west-2',
+  },
+  {
+    value: 'ap-south-1',
+    label: 'Mumbai, ap-south-1',
+  },
+  {
+    value: 'ap-northeast-1',
+    label: 'Tokyo, ap-northeast-1',
+  },
+  {
+    value: 'ap-northeast-2',
+    label: 'Seoul, ap-northeast-2',
+  },
+  {
+    value: 'ap-southeast-1',
+    label: 'Singapore, ap-southeast-1',
+  },
+  {
+    value: 'ap-southeast-2',
+    label: 'Sydney, ap-southeast-2',
+  },
+  {
+    value: 'ca-central-1',
+    label: 'Canada, ca-central-1',
+  },
+  {
+    value: 'eu-central-1',
+    label: 'Frankfurt, eu-central-1',
+  },
+  {
+    value: 'eu-west-1',
+    label: 'Ireland, eu-west-1',
+  },
+  {
+    value: 'eu-west-2',
+    label: 'London, eu-west-2',
+  },
+];
+
+export const pricing = {
+  'us-east-1': {
+    vCpuPerHour: 0.04048,
+    memoryGbPerHour: 0.004445,
+  },
+  'us-east-2': {
+    vCpuPerHour: 0.04048,
+    memoryGbPerHour: 0.004445,
+  },
+  'us-west-1': {
+    vCpuPerHour: 0.04656,
+    memoryGbPerHour: 0.00511,
+  },
+  'us-west-2': {
+    vCpuPerHour: 0.04048,
+    memoryGbPerHour: 0.004445,
+  },
+  'ap-south-1': {
+    vCpuPerHour: 0.04048,
+    memoryGbPerHour: 0.004445,
+  },
+  'ap-northeast-1': {
+    vCpuPerHour: 0.05056,
+    memoryGbPerHour: 0.00553,
+  },
+  'ap-northeast-2': {
+    vCpuPerHour: 0.04656,
+    memoryGbPerHour: 0.00511,
+  },
+  'ap-southeast-1': {
+    vCpuPerHour: 0.05056,
+    memoryGbPerHour: 0.00553,
+  },
+  'ap-southeast-2': {
+    vCpuPerHour: 0.04856,
+    memoryGbPerHour: 0.00532,
+  },
+  'ca-central-1': {
+    vCpuPerHour: 0.04456,
+    memoryGbPerHour: 0.004865,
+  },
+  'eu-central-1': {
+    vCpuPerHour: 0.04656,
+    memoryGbPerHour: 0.00511,
+  },
+  'eu-west-1': {
+    vCpuPerHour: 0.04048,
+    memoryGbPerHour: 0.004445,
+  },
+  'eu-west-2': {
+    vCpuPerHour: 0.04656,
+    memoryGbPerHour: 0.00511,
+  },
+};


### PR DESCRIPTION
### Description
Adds in the ability to select the region that the fargate pricing is for. Additionally, splits up the pricing into the CPU and RAM component, so you can see where to cost is coming from in your configuration.

Also allows for hours less than 1, as it is helpful for me to do minute pricing on high spec jobs.

### Preview
![Screen Shot 2019-06-06 at 10 29 00 am](https://user-images.githubusercontent.com/29904827/58998782-eeadcf80-8845-11e9-9333-ff4b54cbdb7d.jpg)
